### PR TITLE
Fix bug from last PR and improve code

### DIFF
--- a/src/Common/unix/FileStream_unix.cpp
+++ b/src/Common/unix/FileStream_unix.cpp
@@ -5,6 +5,7 @@ std::optional<fs::path> findPathCI(const fs::path& path)
 	if (fs::exists(path)) return path;
 	if (!path.has_parent_path()) return {};
 	auto parentPath = path.parent_path();
+	std::string fName = path.filename().string();
 	if (!fs::exists(parentPath))
 	{
 		auto tempParentPath = findPathCI(parentPath);
@@ -12,12 +13,9 @@ std::optional<fs::path> findPathCI(const fs::path& path)
 			parentPath = std::move(tempParentPath.value());
 		else
 			return {};
+		if (fs::exists(parentPath / fName))
+			return parentPath / fName;
 	}
-
-	std::string fName = path.filename().string();
-
-	if (fs::exists(parentPath / fName))
-		return parentPath / fName;
 
 	std::error_code listErr;
 	for (auto&& dirEntry: fs::directory_iterator(parentPath, listErr))

--- a/src/Common/unix/FileStream_unix.cpp
+++ b/src/Common/unix/FileStream_unix.cpp
@@ -13,19 +13,20 @@ std::optional<fs::path> findPathCI(const fs::path& path)
 		else
 			return {};
 	}
+
 	std::string fName = path.filename().string();
-	if (fs::exists(parentPath))
+
+	if (fs::exists(parentPath / fName))
+		return parentPath / fName;
+
+	std::error_code listErr;
+	for (auto&& dirEntry: fs::directory_iterator(parentPath, listErr))
 	{
-		std::error_code listErr;
-		for (auto&& dirEntry: fs::directory_iterator(parentPath, listErr))
+		std::string dirFName = dirEntry.path().filename().string();
+		if (boost::iequals(dirFName, fName))
 		{
-			std::string dirFName = dirEntry.path().filename().string();
-			if (boost::iequals(dirFName, fName))
-			{
-				return dirEntry;
-			}
+			return dirEntry;
 		}
-		return fName;
 	}
 	return parentPath / fName;
 }


### PR DESCRIPTION
Last PR I misunderstood how the code works and introduced a bug on accident (return statement returning filename fName instead of path)
I removed the if statement before the directory_iterator loop because the constructor that takes an error_code reference constructs the end iterator when a filesystem error occurs so the loop wouldn't run.
I also added an if statement to check if changing the parent directory was enough to find the correct filename so we don't list directories unnecessarily.