### PR TITLE
Update strings.xml for extensions

### DIFF
--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="right_axis">Right Axis</string>
     <string name="extra">Extra</string>
     <string name="nunchuck">Nunchuck</string>
-    <string name="games_folder_description">Add a game path to scan for games displayed in the game list</string>
+    <string name="games_folder_description">Add a WUD/WUX/WUA/WUHB/ISO/ELF/RPX path to scan for games displayed in the game list</string>
     <string name="games_folder_empty">No games folder selected</string>
     <string name="options">Options</string>
     <string name="emulated_controller_selection_description">Selected controller: %1s</string>


### PR DESCRIPTION
Sometimes it can't scan any files, it seems to need Wii U system files. But many people don't know what format those files are needed, WUD/WUX/? I have only tried WUX and WUA, and only WUA is shown. The list doesn't seem to be categorized by file format either
I'm not sure if this is the case, three different extensions for the same game. I only used a Wii U WUD? /ISO? file compressor ten (At that time, Cemu did not support Microphone)? years ago and the result was a WUX file